### PR TITLE
Allow passing flags to PdfDocument.saveAsCopy

### DIFF
--- a/PdfiumAndroid/src/main/cpp/pdfiumandroid.cpp
+++ b/PdfiumAndroid/src/main/cpp/pdfiumandroid.cpp
@@ -743,7 +743,7 @@ Java_io_legere_pdfiumandroid_PdfDocument_nativeGetDestPageIndex(JNIEnv *env, job
 extern "C"
 JNIEXPORT jboolean JNICALL
 Java_io_legere_pdfiumandroid_PdfDocument_nativeSaveAsCopy(JNIEnv *env, jobject thiz, jlong doc_ptr,
-                                                          jobject callback) {
+                                                          jobject callback, jint flags) {
     try {
         jclass callbackClass = env->FindClass("io/legere/pdfiumandroid/PdfWriteCallback");
         if (callback != nullptr && env->IsInstanceOf(callback, callbackClass)) {
@@ -756,7 +756,7 @@ Java_io_legere_pdfiumandroid_PdfDocument_nativeSaveAsCopy(JNIEnv *env, jobject t
             fw.env = env;
 
             auto *doc = reinterpret_cast<DocumentFile *>(doc_ptr);
-            return (jboolean) FPDF_SaveAsCopy(doc->pdfDocument, &fw, FPDF_NO_INCREMENTAL);
+            return (jboolean) FPDF_SaveAsCopy(doc->pdfDocument, &fw, flags);
         }
         return false;
     } catch (std::bad_alloc &e) {

--- a/PdfiumAndroid/src/main/java/io/legere/pdfiumandroid/PdfDocument.kt
+++ b/PdfiumAndroid/src/main/java/io/legere/pdfiumandroid/PdfDocument.kt
@@ -33,7 +33,7 @@ class PdfDocument(
     private external fun nativeGetBookmarkDestIndex(docPtr: Long, bookmarkPtr: Long): Long
     private external fun nativeLoadTextPage(docPtr: Long, pagePtr: Long): Long
     private external fun nativeGetBookmarkTitle(bookmarkPtr: Long): String
-    private external fun nativeSaveAsCopy(docPtr: Long, callback: PdfWriteCallback): Boolean
+    private external fun nativeSaveAsCopy(docPtr: Long, callback: PdfWriteCallback, flags: Int): Boolean
     private external fun nativeGetPageCharCounts(docPtr: Long): IntArray
 
     var parcelFileDescriptor: ParcelFileDescriptor? = null
@@ -218,12 +218,13 @@ class PdfDocument(
     /**
      * Save document as a copy
      * @param callback the [PdfWriteCallback] to be called with the data
+     * @param flags must be one of [FPDF_INCREMENTAL], [FPDF_NO_INCREMENTAL] or [FPDF_REMOVE_SECURITY]
      * @return true if the document was successfully saved
      * @throws IllegalArgumentException if document is closed
      */
-    fun saveAsCopy(callback: PdfWriteCallback): Boolean {
+    fun saveAsCopy(callback: PdfWriteCallback, flags: Int = FPDF_NO_INCREMENTAL): Boolean {
         if (handleAlreadyClosed(isClosed)) return false
-        return nativeSaveAsCopy(mNativeDocPtr, callback)
+        return nativeSaveAsCopy(mNativeDocPtr, callback, flags)
     }
 
     /**
@@ -265,5 +266,9 @@ class PdfDocument(
 
     companion object {
         private val TAG = PdfDocument::class.java.name
+
+        const val FPDF_INCREMENTAL = 1
+        const val FPDF_NO_INCREMENTAL = 2
+        const val FPDF_REMOVE_SECURITY = 3
     }
 }


### PR DESCRIPTION
As the title says, the method FPDF_SaveAsCopy accepts flags which are hardcoded at the moment. This PR allows users to explicitly specify these flags or use the defaults without breaking compatibility.