### PR TITLE
fix(`PdfPage.kt`): correct link rectangle size check

### DIFF
--- a/pdfiumandroid/src/main/java/io/legere/pdfiumandroid/PdfPage.kt
+++ b/pdfiumandroid/src/main/java/io/legere/pdfiumandroid/PdfPage.kt
@@ -538,7 +538,7 @@ class PdfPage(
                 val index = nativeGetDestPageIndex(doc.mNativeDocPtr, linkPtr)
                 val uri = nativeGetLinkURI(doc.mNativeDocPtr, linkPtr)
                 val rect = nativeGetLinkRect(doc.mNativeDocPtr, linkPtr)
-                if (rect.size != RECT_SIZE && (index != -1 || uri != null)) {
+                if (rect.size == RECT_SIZE && (index != -1 || uri != null)) {
                     links.add(
                         PdfDocument.Link(
                             rect.let { rectFloats ->


### PR DESCRIPTION
#34 issue

This pull request includes a small fix in the `PdfPage` class of the `PdfiumAndroid` library. The change corrects the condition that checks the size of the rectangle (`rect.size`) before adding links to ensure proper functionality.