### PR TITLE
Fix bookmark truncation and optimize sibling traversal

### DIFF
--- a/pdfiumandroid/core/src/main/java/io/legere/pdfiumandroid/core/unlocked/PdfDocumentU.kt
+++ b/pdfiumandroid/core/src/main/java/io/legere/pdfiumandroid/core/unlocked/PdfDocumentU.kt
@@ -316,21 +316,18 @@ class PdfDocumentU(
         level: Long,
     ) {
         if (handleAlreadyClosed(isClosed)) return
-        var levelMutable = level
-        val bookmark = Bookmark()
-        bookmark.mNativePtr = bookmarkPtr
-        bookmark.title = nativeDocument.getBookmarkTitle(bookmarkPtr)
-        bookmark.pageIdx = nativeDocument.getBookmarkDestIndex(mNativeDocPtr, bookmarkPtr)
-        tree.add(bookmark)
-        val child = nativeDocument.getFirstChildBookmark(mNativeDocPtr, bookmarkPtr)
-        if (child != 0L && levelMutable < MAX_RECURSION) {
-            println("child: $child, level: $levelMutable")
-            recursiveGetBookmark(bookmark.children, child, ++levelMutable)
-        }
-        val sibling = nativeDocument.getSiblingBookmark(mNativeDocPtr, bookmarkPtr)
-        if (sibling != 0L && levelMutable < MAX_RECURSION) {
-            println("sibling: $sibling, level: $levelMutable")
-            recursiveGetBookmark(tree, sibling, levelMutable)
+        var currentPtr = bookmarkPtr
+        while (currentPtr != 0L) {
+            val bookmark = Bookmark()
+            bookmark.mNativePtr = currentPtr
+            bookmark.title = nativeDocument.getBookmarkTitle(currentPtr)
+            bookmark.pageIdx = nativeDocument.getBookmarkDestIndex(mNativeDocPtr, currentPtr)
+            tree.add(bookmark)
+            val child = nativeDocument.getFirstChildBookmark(mNativeDocPtr, currentPtr)
+            if (child != 0L && level < MAX_RECURSION) {
+                recursiveGetBookmark(bookmark.children, child, level + 1)
+            }
+            currentPtr = nativeDocument.getSiblingBookmark(mNativeDocPtr, currentPtr)
         }
     }
 


### PR DESCRIPTION
Fixes an issue where the Table of Contents (bookmarks) gets truncated prematurely and prevents potential `StackOverflowError`s during traversal.

The previous implementation had a depth-state leakage (`++levelMutable`). Processing a child incorrectly increased the recursion depth counter for subsequent siblings. This caused siblings to hit the `MAX_RECURSION` limit prematurely, truncating the list. Furthermore, using recursion for sibling traversal risks a `StackOverflowError` on documents with many siblings at the same level.

Refactored `recursiveGetBookmark` to traverse siblings iteratively using a `while` loop, and strictly use recursion only for children (depth traversal). This segregates depth from breadth, resolving the depth leak and preventing stack overflows.