### PR TITLE
fix(render): pass full flags to FPDF_FFLDraw to preserve REVERSE_BYTE_ORDER

### DIFF
--- a/pdfiumandroid/core/src/main/cpp/pdfiumandroid.cpp
+++ b/pdfiumandroid/core/src/main/cpp/pdfiumandroid.cpp
@@ -1643,7 +1643,14 @@ static void NativePage_nativeRenderPageBitmap(JNIEnv *env, jclass,
                               0, flags);
 
         if (render_annot) {
-            FPDF_FFLDraw(form, pdfBitmap, page, start_x, start_y, (int) draw_size_hor, (int) draw_size_ver, 0, FPDF_ANNOT);
+            // Pass the full `flags` (which already contains
+            // FPDF_REVERSE_BYTE_ORDER | FPDF_ANNOT) so the form-widget pass
+            // writes pixels in the same byte order as FPDF_RenderPageBitmap
+            // above. Using just FPDF_ANNOT drops FPDF_REVERSE_BYTE_ORDER and
+            // causes form widgets to be written as BGRA into a buffer that
+            // Android then interprets as RGBA, swapping the R and B channels
+            // on every annotation/widget appearance.
+            FPDF_FFLDraw(form, pdfBitmap, page, start_x, start_y, (int) draw_size_hor, (int) draw_size_ver, 0, flags);
             FPDFDOC_ExitFormFillEnvironment(form);
         }
 


### PR DESCRIPTION
## Summary

`FPDF_FFLDraw` in `nativeRenderPageBitmap` is called with just `FPDF_ANNOT` instead of the surrounding `flags` variable. This drops `FPDF_REVERSE_BYTE_ORDER` for the form-widget rendering pass and produces a swap of the **R** and **B** color channels on every annotation / form-field appearance.

This is the underlying cause of:

- wonday/react-native-pdf#975 — *some annotations change color (version >= 6.7.7)*
- johngray1965/PdfiumAndroidKt#40 — *Signature's color is incorrect in Android*
- wonday/react-native-pdf#951 — *Incorrect color rendering for embedded PNG images (Red appears as Blue)*

The fix is a one-line change in `nativeRenderPageBitmap` so the `FPDF_FFLDraw` pass uses the same `flags` (`FPDF_REVERSE_BYTE_ORDER | FPDF_ANNOT`) as the `FPDF_RenderPageBitmap` call directly above it.

## Root cause

In `pdfiumandroid/core/src/main/cpp/pdfiumandroid.cpp`, `NativePage_nativeRenderPageBitmap`:

```cpp
format = FPDFBitmap_BGRA;                             // (~line 1597)
...
int flags = FPDF_REVERSE_BYTE_ORDER;                  // (line 1620)
if (render_annot) {
    form = FPDFDOC_InitFormFillEnvironment(doc->pdfDocument, &form_callbacks);
    flags |= FPDF_ANNOT;
}
...
FPDF_RenderPageBitmap(pdfBitmap, page,                // (line 1640)
                      start_x, start_y,
                      (int) draw_size_hor, (int) draw_size_ver,
                      0, flags);                      // <-- writes RGBA into BGRA buffer

if (render_annot) {
    FPDF_FFLDraw(form, pdfBitmap, page, start_x, start_y,
                 (int) draw_size_hor, (int) draw_size_ver,
                 0, FPDF_ANNOT);                      // <-- BUG: writes BGRA, no reverse
    FPDFDOC_ExitFormFillEnvironment(form);
}
```

The bitmap is allocated as `FPDFBitmap_BGRA`. The `FPDF_REVERSE_BYTE_ORDER` flag flips PDFium's output to RGBA in memory, which is what Android's `Bitmap.Config.RGBA_8888` expects. The first call respects this contract.

`FPDF_FFLDraw` then writes the form-widget appearance into the same buffer, but **without** `FPDF_REVERSE_BYTE_ORDER`. The widget pixels go in as BGRA. Android then interprets the buffer as RGBA, so R and B are swapped on every widget.

That's why the visual symptom is reported only on form widgets / signatures / image-backed annotations — never on plain page content (which goes through the correctly-flagged `FPDF_RenderPageBitmap` path).

## Fix

```diff
         if (render_annot) {
-            FPDF_FFLDraw(form, pdfBitmap, page, start_x, start_y, (int) draw_size_hor, (int) draw_size_ver, 0, FPDF_ANNOT);
+            // Pass the full `flags` (which already contains
+            // FPDF_REVERSE_BYTE_ORDER | FPDF_ANNOT) so the form-widget pass
+            // writes pixels in the same byte order as FPDF_RenderPageBitmap
+            // above. Using just FPDF_ANNOT drops FPDF_REVERSE_BYTE_ORDER and
+            // causes form widgets to be written as BGRA into a buffer that
+            // Android then interprets as RGBA, swapping the R and B channels
+            // on every annotation/widget appearance.
+            FPDF_FFLDraw(form, pdfBitmap, page, start_x, start_y, (int) draw_size_hor, (int) draw_size_ver, 0, flags);
             FPDFDOC_ExitFormFillEnvironment(form);
         }
```

`flags` at this point is `FPDF_REVERSE_BYTE_ORDER | FPDF_ANNOT` (`render_annot` is the only branch that reaches here, and it ORs `FPDF_ANNOT` in on line 1628), so the fix preserves the `FPDF_ANNOT` semantics that were intended.

## Verification — without Android

The bug and the fix were both reproduced from raw PDFium API calls on macOS using [pypdfium2](https://github.com/pypdfium2-team/pypdfium2) (PDFium build 149.0.7802.0), so the diagnosis is independent of `PdfiumAndroidKt`/Android internals.

The script renders the same PDF three ways into a `BGRA` bitmap allocated with `FPDFBitmap_CreateEx`, mirroring the exact sequence in `nativeRenderPageBitmap`:

| Strategy | `FPDF_RenderPageBitmap` flags | `FPDF_FFLDraw` flags | Center pixel of widget |
|---|---|---|---|
| `control` (no widget) | `REVERSE_BYTE_ORDER` | — | `RGB(255, 255, 255)` |
| `buggy` (current code) | `REVERSE_BYTE_ORDER \| ANNOT` | `ANNOT` | **`RGB(255, 225, 207)`** |
| `fixed` (this PR) | `REVERSE_BYTE_ORDER \| ANNOT` | `REVERSE_BYTE_ORDER \| ANNOT` | **`RGB(207, 225, 255)`** |

R and B are exactly swapped between buggy and fixed (255 ↔ 207). The widget in the test PDF is authored as a light blue raster; under the buggy flag combination it renders as a peach / light orange — which is the symptom users report.

The full reproduction script is `verify_fix.py` (attached in this PR description). It needs only `pypdfium2` and `pillow`, and a PDF that contains a signature widget whose appearance stream is an embedded raster image.

## Compatibility / risk

- The change only affects the form-widget pass inside the `if (render_annot)` branch of `nativeRenderPageBitmap`. The `nativeRenderPageBitmapWithMatrix` paths and the page-content path are untouched.
- Consumers who currently work around this by disabling annotation rendering on Android (e.g. `enableAnnotationRendering={Platform.OS === 'ios'}` in react-native-pdf) will still work after this PR, and can drop the workaround.
- I verified end-to-end on a Samsung Galaxy S24 (arm64-v8a, Android 14) with `react-native-pdf@7.0.4` against a locally-vendored `pdfiumandroid` built from `main` with this patch applied: the previously-orange widget now renders blue, matching iOS / desktop viewers.

## Test plan

- [x] Host reproduction (pypdfium2) confirms R/B swap is gone after the change.
- [x] Library builds successfully with NDK 27.1.12297006 + AGP 8.x + CMake + the prebuilt `libpdfium.so` shipped in the repo, on `arm64-v8a`, `armeabi-v7a`, `x86`, `x86_64`.
- [x] APK packaged with the rebuilt `libpdfiumandroid.so` (MD5 `00e0ad7b…`) renders the previously-affected PDF correctly on a real Samsung Galaxy S24.
- [ ] Maintainer to add a regression test against an annotated/signed PDF if desired.

## Attached evidence (not in the diff, just for the description)

- `verify_fix.py` — host-side reproduction (pure PDFium API, no Android).
- `render_buggy.png` — host render with the current code path (peach widget).
- `render_fixed.png` — host render with this PR's flag (blue widget).
- `android-after-patch.png` — real Galaxy S24 screenshot of `react-native-pdf` after the patch is wired in.
